### PR TITLE
Fix sorting output and make cidrScan run as root

### DIFF
--- a/netscan.sh
+++ b/netscan.sh
@@ -5,13 +5,23 @@ green=$(tput setaf 2)
 yellow=$(tput setaf 3)
 reset=$(tput sgr0)
 
-# if [ "$(id -u)" -ne 0 ]; then
-# printf "%s\n\n\t${red}please run this script as sudo\n\n${reset}"
-# exit 0;
-# fi
+run_as_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        if command -v sudo >/dev/null 2>&1; then
+            sudo "${0}" "$@"
+            exit $?
+        elif command -v doas >/dev/null 2>&1; then
+            doas "${0}" "$@"
+            exit $?
+        else
+            die 1 "This script must be executed as root!"
+        fi
+    fi
+}
+
 cidrScan() {
     printf "%s${yellow}Scanning alive ips in CIDR block:${red} $1 ${reset} \n"
-    sudo masscan --range "$1" -p7,9,13,21-23,25-26,37,53,79-81,88,106,110-111,113,119,135,139,143-144,179,199,389,427,443-445,465,513-515,543-544,548,554,587,631,646,873,990,993,995,1025-1029,1110,1433,1720,1723,1755,1900,2000-2001,2049,2121,2717,3000,3128,3306,3389,3986,4899,5000,5009,5051,5060,5101,5190,5357,5432,5631,5666,5800,5900,6000-6001,6646,7070,8000,8008-8009,8080-8081,8443,8888,9100,9999-10000,32768,49152-49157 --rate 1000 --output-format json --output-filename scan-results.json
+    masscan --range "$1" -p7,9,13,21-23,25-26,37,53,79-81,88,106,110-111,113,119,135,139,143-144,179,199,389,427,443-445,465,513-515,543-544,548,554,587,631,646,873,990,993,995,1025-1029,1110,1433,1720,1723,1755,1900,2000-2001,2049,2121,2717,3000,3128,3306,3389,3986,4899,5000,5009,5051,5060,5101,5190,5357,5432,5631,5666,5800,5900,6000-6001,6646,7070,8000,8008-8009,8080-8081,8443,8888,9100,9999-10000,32768,49152-49157 --rate 1000 --output-format json --output-filename scan-results.json
 
     printf "%s\n\t${yellow}Parsing alive ips and ports:${red} $1 ${reset} \n"
     sed <scan-results.json -e '/^\[/d' -e'/^\]/d' -e 's/,$//' | jq -r '[.ip, .ports[0].port] | @tsv' | sed 's/\t/:/' | sort -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n  > alive-hosts
@@ -45,9 +55,9 @@ cidrScan() {
 asnScan() {
     printf "%s\n\t${yellow}Looking for CIDR in asn number:${red}$1${reset}\n"
     
-    curl -s "https://api.bgpview.io/asn/$1/prefixes" | jq ".data.ipv4_prefixes[].parent.prefix" | sed -E -e "s/\"//g" | uniq | sort >ipv4prefixes
+    curl -s "https://api.bgpview.io/asn/$1/prefixes" | jq ".data.ipv4_prefixes[].parent.prefix" | sed -E -e "s/\"//g" | sort | uniq > ipv4prefixes
 
-    curl -s "https://api.bgpview.io/asn/$1/prefixes" | jq ".data.ipv6_prefixes[].parent.prefix" | sed -E -e "s/\"//g" | uniq | sort >ipv6prefixes
+    curl -s "https://api.bgpview.io/asn/$1/prefixes" | jq ".data.ipv6_prefixes[].parent.prefix" | sed -E -e "s/\"//g" | sort | uniq > ipv6prefixes
     # grep <asn.txt -Eo "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9][0-9]" | tee "$1"cidr
     cidr=$(cat ipv4prefixes ipv6prefixes)
     for i in $cidr; do
@@ -67,6 +77,7 @@ while [ "$#" -gt 0 ]; do
         asnScan "$2" && exit 0
         ;;
     -c | --cidr)
+        run_as_root
         dir=$(echo "$2" | cut -d "/" -f1)
         mkdir -p "${dir}"
         cd "${dir}" || exit


### PR DESCRIPTION
The following changes are made:

  - Sorting after running uniq is usually meaningless as uniq checks on line-by-line basis
  - Make cidrScan run as root when the script is not running as root if either sudo or doas are present